### PR TITLE
Add improvements for packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include COPYING
+include README.md
+include pyproject.toml
+include tests/*.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["cython"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[metadata]
-description-file = README.md

--- a/setup.py
+++ b/setup.py
@@ -24,17 +24,20 @@
 #
 
 import sys
-from distutils.core import setup
-from distutils.extension import Extension
-from Cython.Distutils import build_ext
 from distutils.errors import CCompilerError, DistutilsPlatformError
 
+from Cython.Distutils import build_ext
+from setuptools import setup
+from setuptools.extension import Extension
+
 ext_modules = [
-    Extension("rencode._rencode",
-              extra_compile_args=["-O3"],
-              sources=["rencode/rencode.pyx"]
-    )
+    Extension(
+        "rencode._rencode",
+        extra_compile_args=["-O3"],
+        sources=["rencode/rencode.pyx"],
+    ),
 ]
+
 
 class optional_build_ext(build_ext):
     # This class allows C extension building to fail.
@@ -62,22 +65,18 @@ available.""")
         print('*' * 70)
         print(exc)
 
-description = """\
-The rencode module is similar to bencode from the BitTorrent project. For
-complex, heterogeneous data structures with many small elements, r-encodings
-take up significantly less space than b-encodings. This version of rencode is
-a complete rewrite in Cython to attempt to increase the performance over the
-pure Python module written by Petru Paler, Connelly Barnes et al.
-"""
 
 setup(
   name="rencode",
   version="1.0.5",
   packages=["rencode"],
-  description=description,
+  description="Web safe object pickling/unpickling",
+  long_description=open("README.md").read(),
+  long_description_content_type="text/markdown",
+  license='GPLv3',
   author="Andrew Resch",
   author_email="andrewresch@gmail.com",
   url="https://github.com/aresch/rencode",
   cmdclass={'build_ext': optional_build_ext},
-  ext_modules=ext_modules
+  ext_modules=ext_modules,
 )


### PR DESCRIPTION
Added:
 * setup.py long_description, using contents of README.md.
 * MANIFEST.in file to include relevant files in sdist tarball.
 * Missing license info

Changed:
 * Import from setuptools instead of distutils to enable building
   wheels.

Fixed:
 * Fixes #11 pip cython requirement issue using a pyproject.toml file
   to install cython before running setup.py.

Removed:
 * Unneeded setup.cfg file.