### PR TITLE
cleanup and improve build.py

### DIFF
--- a/build.py
+++ b/build.py
@@ -10,8 +10,6 @@ from setuptools import Distribution
 from setuptools import Extension
 from setuptools.command.build_ext import build_ext
 
-COMPILE_ARGS = ["-O3"]
-
 LINK_ARGS: list[str] = []
 INCLUDE_DIRS: list[str] = []
 LIBRARIES: list[str] = []
@@ -22,7 +20,6 @@ def build() -> None:
         Extension(
             "*",
             ["rencode/*.pyx"],
-            extra_compile_args=COMPILE_ARGS,
             extra_link_args=LINK_ARGS,
             include_dirs=INCLUDE_DIRS,
             libraries=LIBRARIES,

--- a/build.py
+++ b/build.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 import shutil
-import platform
 
 from pathlib import Path
 


### PR DESCRIPTION
Hi,

This is a simple update for the `build.py` file which i use for gentoo in https://github.com/gentoo/gentoo/pull/43015

I've made two commits. 
The first simply removes `import platform` which was introduces in 591b9f4 but later not required anymore with commit e7ec8ea

The second commit removes `COMPILE_FLAGS` altogether. 
There is no reason to force a certain optimization on users. Users should be able to decide themselves how to optimize their packages.

Regards
Michael